### PR TITLE
AUI-1901 Padding makes scroll bar disappeared.

### DIFF
--- a/lib/_forms.scss
+++ b/lib/_forms.scss
@@ -87,6 +87,7 @@ input[type="color"],
   color: $gray;
   @include border-radius($inputBorderRadius);
   vertical-align: middle;
+  box-sizing: border-box;
 }
 
 // Reset appearance properties for textual inputs and textarea


### PR DESCRIPTION
Hey Jon

This is a fix for AUI-1901.

In boostrap, the code I am trying to change is removed by this commit : https://github.com/twbs/bootstrap/commit/13bc74b636f4a9905010df84fc07790ccced0c93#diff-57a5fbf005ecc202d1e7e08c11f73b93

But, it seems not easy to backport it as the code had changed a lot.

I wonder if we can solely fix the issue for our alloy-boostrap.

Or you insist we should stick to the original fix.

BTW, I have some problem of making alloy-boostrap.

Could you do me a favour to regenerate code?

Many thanks
John. 
